### PR TITLE
 Sidestepping primitiveId issues by replacing it with an instanceId.

### DIFF
--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -1605,7 +1605,7 @@ void pbrtObjectInstance(const std::string &name) {
     // nObjectInstancesUsed will be 1 for the first entry.
     // TransformedPrimitive's intersect routine overwrites the SurfaceIntersection's instanceId field
     std::shared_ptr<Primitive> prim(
-        std::make_shared<TransformedPrimitive>(in[0], animatedInstanceToWorld, nObjectInstancesUsed));
+        std::make_shared<TransformedPrimitive>(in[0], animatedInstanceToWorld, (uint32_t)nObjectInstancesUsed));
     renderOptions->primitives.push_back(prim);
     renderOptions->instanceNames.push_back(name); // MM
 }

--- a/src/core/interaction.h
+++ b/src/core/interaction.h
@@ -152,7 +152,7 @@ class SurfaceInteraction : public Interaction {
     
     // Added by TLian (and MMara) in order to do pixel-wise classification
     uint32_t instanceId = 0;
-    uint32_t materialId;
+    uint32_t materialId = 0;
     
     // Added after book publication. Shapes can optionally provide a face
     // index with an intersection point for use in Ptex texture lookups.

--- a/src/core/interaction.h
+++ b/src/core/interaction.h
@@ -150,8 +150,8 @@ class SurfaceInteraction : public Interaction {
     mutable Vector3f dpdx, dpdy;
     mutable Float dudx = 0, dvdx = 0, dudy = 0, dvdy = 0;
     
-    // Added by Trisha in order to do pixel-wise classification
-    uint32_t primitiveId;
+    // Added by TLian (and MMara) in order to do pixel-wise classification
+    uint32_t instanceId = 0;
     uint32_t materialId;
     
     // Added after book publication. Shapes can optionally provide a face

--- a/src/core/primitive.cpp
+++ b/src/core/primitive.cpp
@@ -42,7 +42,6 @@ namespace pbrt {
 STAT_MEMORY_COUNTER("Memory/Primitives", primitiveMemory);
 
 // Primitive Method Definitions
-uint32_t Primitive::nextprimitiveId = 1;
 Primitive::~Primitive() {}
     
 const AreaLight *Aggregate::GetAreaLight() const {
@@ -70,8 +69,9 @@ void Aggregate::ComputeScatteringFunctions(SurfaceInteraction *isect,
 
 // TransformedPrimitive Method Definitions
 TransformedPrimitive::TransformedPrimitive(std::shared_ptr<Primitive> &primitive,
-                                           const AnimatedTransform &PrimitiveToWorld)
-    : primitive(primitive), PrimitiveToWorld(PrimitiveToWorld) {
+                                           const AnimatedTransform &PrimitiveToWorld, 
+                                           uint32_t instanceID)
+    : primitive(primitive), PrimitiveToWorld(PrimitiveToWorld), instanceId(instanceId) {
     primitiveMemory += sizeof(*this);
 }
 
@@ -86,7 +86,7 @@ bool TransformedPrimitive::Intersect(const Ray &r,
     // Transform instance's intersection data to world space
     if (!InterpolatedPrimToWorld.IsIdentity())
         *isect = InterpolatedPrimToWorld(*isect);
-    isect->primitiveId = primitiveId; // Added by Trisha
+    isect->instanceId = instanceId; // Added by MMara
     CHECK_GE(Dot(isect->n, isect->shading.n), 0);
     return true;
 }
@@ -122,7 +122,6 @@ bool GeometricPrimitive::Intersect(const Ray &r,
     if (!shape->Intersect(r, &tHit, isect)) return false;
     r.tMax = tHit;
     isect->primitive = this;
-    isect->primitiveId = primitiveId; // Added by Trisha
     isect->materialId = material->materialId; // Added by Trisha
     CHECK_GE(Dot(isect->n, isect->shading.n), 0.);
     // Initialize _SurfaceInteraction::mediumInterface_ after _Shape_

--- a/src/core/primitive.cpp
+++ b/src/core/primitive.cpp
@@ -70,7 +70,7 @@ void Aggregate::ComputeScatteringFunctions(SurfaceInteraction *isect,
 // TransformedPrimitive Method Definitions
 TransformedPrimitive::TransformedPrimitive(std::shared_ptr<Primitive> &primitive,
                                            const AnimatedTransform &PrimitiveToWorld, 
-                                           uint32_t instanceID)
+                                           uint32_t instanceId)
     : primitive(primitive), PrimitiveToWorld(PrimitiveToWorld), instanceId(instanceId) {
     primitiveMemory += sizeof(*this);
 }

--- a/src/core/primitive.h
+++ b/src/core/primitive.h
@@ -52,7 +52,7 @@ class Primitive {
   public:
     // Primitive Interface
     virtual ~Primitive();
-    Primitive() : primitiveId(nextprimitiveId++) { }
+    Primitive() { }
     virtual Bounds3f WorldBound() const = 0;
     virtual bool Intersect(const Ray &r, SurfaceInteraction *) const = 0;
     virtual bool IntersectP(const Ray &r) const = 0;
@@ -62,13 +62,6 @@ class Primitive {
                                             MemoryArena &arena,
                                             TransportMode mode,
                                             bool allowMultipleLobes) const = 0;
-    
-    // The following are added by TLian in order to be able to return pixel-wise classification
-    const uint32_t primitiveId;
-    
-    protected:
-    static uint32_t nextprimitiveId;
-    
 };
 
 // GeometricPrimitive Declarations
@@ -87,7 +80,6 @@ class GeometricPrimitive : public Primitive {
     void ComputeScatteringFunctions(SurfaceInteraction *isect,
                                     MemoryArena &arena, TransportMode mode,
                                     bool allowMultipleLobes) const;
-
   private:
     // GeometricPrimitive Private Data
     std::shared_ptr<Shape> shape;
@@ -101,7 +93,8 @@ class TransformedPrimitive : public Primitive {
   public:
     // TransformedPrimitive Public Methods
     TransformedPrimitive(std::shared_ptr<Primitive> &primitive,
-                         const AnimatedTransform &PrimitiveToWorld);
+                         const AnimatedTransform &PrimitiveToWorld, 
+                         uint32_t instanceId = 0);
     bool Intersect(const Ray &r, SurfaceInteraction *in) const;
     bool IntersectP(const Ray &r) const;
     const AreaLight *GetAreaLight() const { return nullptr; }
@@ -116,11 +109,11 @@ class TransformedPrimitive : public Primitive {
     Bounds3f WorldBound() const {
         return PrimitiveToWorld.MotionBounds(primitive->WorldBound());
     }
-
   private:
     // TransformedPrimitive Private Data
     std::shared_ptr<Primitive> primitive;
     const AnimatedTransform PrimitiveToWorld;
+    uint32_t instanceId;
 };
 
 // Aggregate Declarations

--- a/src/integrators/metadata.cpp
+++ b/src/integrators/metadata.cpp
@@ -72,7 +72,7 @@ Spectrum MetadataIntegrator::Li(const RayDifferential &ray,
         L = Spectrum(isect.materialId);
         
     }else if(strategy == MetadataStrategy::mesh){
-        L = Spectrum(isect.primitiveId);
+        L = Spectrum(isect.instanceId);
         
     }else if(strategy == MetadataStrategy::coordinates){
         // Return world coordinates of intersection.


### PR DESCRIPTION
A nice side effect is that the used IDs are contiguous starting at 1 (no more 8 digit IDs unless you actually have 10 million objects in the scene).