### PR TITLE
Fix crash with RealisticCamera, and make MetadataIntegrator provide reasonable results.

### DIFF
--- a/src/core/integrator.cpp
+++ b/src/core/integrator.cpp
@@ -235,6 +235,7 @@ void SamplerIntegrator::Render(const Scene &scene) {
     const int tileSize = 16;
     Point2i nTiles((sampleExtent.x + tileSize - 1) / tileSize,
                    (sampleExtent.y + tileSize - 1) / tileSize);
+    const bool ignoreRayWeight = IgnoreRayWeight();
     ProgressReporter reporter(nTiles.x * nTiles.y, "Rendering");
     {
         ParallelFor2D([&](Point2i tile) {
@@ -316,6 +317,8 @@ void SamplerIntegrator::Render(const Scene &scene) {
                     VLOG(1) << "Camera sample: " << cameraSample << " -> ray: " <<
                         ray << " -> L = " << L;
 
+                    if (ignoreRayWeight)
+                        rayWeight = 1.0f; // Added by MMara
                     // Add camera ray's contribution to image
                     filmTile->AddSample(cameraSample.pFilm, L, rayWeight);
 

--- a/src/core/integrator.h
+++ b/src/core/integrator.h
@@ -94,6 +94,8 @@ class SamplerIntegrator : public Integrator {
                               const SurfaceInteraction &isect,
                               const Scene &scene, Sampler &sampler,
                               MemoryArena &arena, int depth) const;
+    //Added by MMara so that the metadata integrator can override to ignore
+    virtual bool IgnoreRayWeight() const { return false; }
 
   protected:
     // SamplerIntegrator Protected Data

--- a/src/integrators/metadata.h
+++ b/src/integrators/metadata.h
@@ -61,7 +61,7 @@ class MetadataIntegrator : public SamplerIntegrator {
     Spectrum Li(const RayDifferential &ray, const Scene &scene,
                 Sampler &sampler, MemoryArena &arena, int depth) const;
     void Preprocess(const Scene &scene, Sampler &sampler);
-
+    virtual bool IgnoreRayWeight() const override { return true; }
   private:
     // MetadataIntegrator Private Data
     const MetadataStrategy strategy;


### PR DESCRIPTION
MetadataIntegrator now ignores ray weights, which should fix weird metadata results. Also disabled currently unused crashing code.