### PR TITLE
Basic microlens support for OmniCamera, and lenstool for creating them.

### DIFF
--- a/src/cameras/omni.h
+++ b/src/cameras/omni.h
@@ -75,10 +75,10 @@ class OmniCamera : public Camera {
     OmniCamera(const AnimatedTransform &CameraToWorld, Float shutterOpen,
                     Float shutterClose, Float apertureDiameter, Float filmdistance,
                     Float focusDistance, bool simpleWeighting, bool noWeighting,
-                    bool caFlag, std::vector<OmniCamera::LensElementInterface> &lensData, 
-                    std::vector<OmniCamera::LensElementInterface> &microlensData,
-                    Vector2i microlensDims, std::vector<Float> & microlensOffsets, float microlensSensorOffset,
-                    Film *film, const Medium *medium);
+                    bool caFlag, const std::vector<OmniCamera::LensElementInterface> &lensData, 
+                    const std::vector<OmniCamera::LensElementInterface> &microlensData,
+                    Vector2i microlensDims, const std::vector<Vector2f> & microlensOffsets, 
+                    float microlensSensorOffset, Film *film, const Medium *medium);
     Float GenerateRay(const CameraSample &sample, Ray *) const;
 
   private:
@@ -95,6 +95,13 @@ class OmniCamera : public Camera {
 
     MicrolensData microlens;
 
+    struct MicrolensElement {
+        Point2f center;
+        Bounds2f centeredBounds;
+        Point2i index;
+        Transform ComputeCameraToMicrolens() const;
+    };
+
     // OmniCamera Private Methods
     Float LensRearZ() const { return elementInterfaces.back().thickness; }
     Float LensFrontZ() const {
@@ -107,7 +114,7 @@ class OmniCamera : public Camera {
         return elementInterfaces.back().apertureRadius.x;
     }
     bool TraceLensesFromFilm(const Ray &ray, const std::vector<LensElementInterface>& interfaces, Ray *rOut,
-        const Transform CameraToLens) const;
+        const Transform CameraToLens, const Bounds2f& bounds) const;
     static bool IntersectSphericalElement(Float radius, Float zCenter,
                                           const Ray &ray, Float *t,
                                           Normal3f *n);
@@ -129,9 +136,16 @@ class OmniCamera : public Camera {
                             Float *sampleBoundsArea) const;
 
     IntersectResult TraceElement(const LensElementInterface &element, const Ray& rLens, const Float& elementZ,
-         Float& t, Normal3f& n, bool& isStop) const;
+         Float& t, Normal3f& n, bool& isStop, const Bounds2f& bounds) const;
 
     void TestExitPupilBounds() const;
+
+    Point2i MicrolensIndex(const Point2f& p) const;
+    Point2f MicrolensCenterFromIndex(const Point2i& idx) const;
+    MicrolensElement MicrolensElementFromIndex(const Point2i& idx) const;
+    MicrolensElement ComputeMicrolensElement(const Ray & filmRay) const;
+
+    bool TraceFullLensSystemFromFilm(const Ray & rIn, Ray * rOut) const;
 
     Point3f SampleMicrolensPupil(const Point2f &pFilm, const Point2f &lensSample,
         Float *sampleBoundsArea) const;


### PR DESCRIPTION
insertmicrolens <inputlenssystem> <inputmicrolenssystem> <outputcombinedlensystem>
```
insertmicrolens options:
    --xdim <n>             How many microlenses span the X direction. Default: 16
    --ydim <n>             How many microlenses span the Y direction. Default: 16
    --filmwidth <n>        Width of target film in mm. Default: 20.0
    --filmheight <n>       Height of target film in mm. Default: 20.0
    --filmtolens <n>       Distance from film to back of main lens system (in mm). Default: 50.0
    --filmtomicrolens <n>  Distance from film to back of microlens. Default: 0.0 
```