### PR TITLE
Aspheric Lens Support for OmniCamera

### DIFF
--- a/src/cameras/omni.h
+++ b/src/cameras/omni.h
@@ -63,6 +63,9 @@ class OmniCamera : public Camera {
         Transform transform;
         Float thickness;
         Float eta;
+        std::vector<Float> asphericCoefficients;
+        Float zMin;
+        Float zMax;
     };
     struct MicrolensData {
         std::vector<LensElementInterface> elementInterfaces;


### PR DESCRIPTION
Support for standard aspherical lens.

The file format allows for an arbitrarily long array of aspherical coefficients, (the alphas in the surface profile formula here: https://en.wikipedia.org/wiki/Aspheric_lens), specified like

`"aspheric_coefficients": [-3.52130E-02, 8.54520E-03, -1.60350E-03, 1.95350E-04, -1.56610E-05, 7.31140E-07, -1.44480E-08]`

in the lens element's json. 

We use GSL for root finding during the intersection, starting the bounds by intersecting tight bounding planes precalculated for each lens element.